### PR TITLE
Added: language field and notes for pre-processing db

### DIFF
--- a/config/install/migrate_plus.migration.joomla_node.yml
+++ b/config/install/migrate_plus.migration.joomla_node.yml
@@ -19,10 +19,18 @@ process:
   sticky:
     plugin: default_value
     default_value: 0
-  #langcode:
-  #  plugin: default_value
-  #  source: language
-  #  default_value: "und"
+  # Notes - occasionally you will get an error about
+  # joomlamigrate.settings already existing when re-installing
+  # a workaround is to run drush config-delete joomlamigrate.settings
+  # clear cache and run the install again
+  # PREPROCESSING STEPS
+  # prepare Joomla database language field in content table to
+  # display as en for english or es for spanish instead of en-US
+  # or es-ES
+  langcode:
+    plugin: default_value
+    source: language
+    default_value: "und"
   #status: state
   created:
     plugin: callback

--- a/config/install/migrate_plus.migration.joomla_user.yml
+++ b/config/install/migrate_plus.migration.joomla_user.yml
@@ -7,12 +7,12 @@ migration_group: joomla
 source:
   plugin: joomla_user
 destination:
-  plugin: entity:user
+  plugin: entity_user
 process:
   pass: password
   mail: email
   init: email
-  # status: status
+  status: status
   roles:
     plugin: default_value
     default_value: 2
@@ -24,7 +24,7 @@ process:
   name:
     plugin: dedupe_entity
     # The name of the source field containing the username.
-    source: username
+    source: name
     # These next two settings identify the destination-side field to check for
     # duplicates. They say "see if the incoming 'name' matches any existing
     # 'name' field in any 'user' entity".
@@ -45,7 +45,7 @@ process:
     # 'yyyy-mm-dd hh:mm:ss', but Drupal wants a UNIX timestamp for 'created'.
     source: registerDate
     callable: strtotime
-  field_name: name
+  full_name: name
   access: block
 
   # Our source data only has a single timestamp value, 'registered', which we


### PR DESCRIPTION
The typo push was removed (f40dd2b) but the language field edit is still valid (c71f9c3)